### PR TITLE
Sleep improvements

### DIFF
--- a/VirtualKVM/Base.lproj/MainMenu.xib
+++ b/VirtualKVM/Base.lproj/MainMenu.xib
@@ -42,13 +42,13 @@
                         <action selector="toggleTargetDisplayOption:" target="lVf-z2-2S9" id="b5O-ZI-yr6"/>
                     </connections>
                 </menuItem>
-                <menuItem title="Auto Disable Idle Sleep" state="on" id="pFx-q3-0Qh">
+                <menuItem title="Allow Display To Sleep" state="on" id="pFx-q3-0Qh">
                     <modifierMask key="keyEquivalentModifierMask"/>
                     <connections>
                         <action selector="toggleSleepOption:" target="lVf-z2-2S9" id="NHc-LJ-hGX"/>
                     </connections>
                 </menuItem>
-                <menuItem title="Auto Disable Display Sleep" state="on" id="KqC-rJ-r1W">
+                <menuItem title="Allow System To Sleep" state="on" id="KqC-rJ-r1W">
                     <modifierMask key="keyEquivalentModifierMask"/>
                     <connections>
                         <action selector="toggleSleepOption:" target="lVf-z2-2S9" id="VTr-LX-B8Y"/>

--- a/VirtualKVM/Base.lproj/MainMenu.xib
+++ b/VirtualKVM/Base.lproj/MainMenu.xib
@@ -19,7 +19,6 @@
                 <outlet property="toggleBluetoothMenuItem" destination="5RI-2K-t5L" id="q2q-LS-th5"/>
                 <outlet property="toggleDisplayMenuItem" destination="Beb-Ne-3cM" id="e2R-MG-QZB"/>
                 <outlet property="toggleIdleSleepMenuItem" destination="pFx-q3-0Qh" id="YFB-yG-DEw"/>
-                <outlet property="toggleSleepMenuItem" destination="KqC-rJ-r1W" id="nqo-ba-9h6"/>
             </connections>
         </customObject>
         <customObject id="Voe-Tx-rLC" customClass="KVMAppDelegate"/>
@@ -42,16 +41,10 @@
                         <action selector="toggleTargetDisplayOption:" target="lVf-z2-2S9" id="b5O-ZI-yr6"/>
                     </connections>
                 </menuItem>
-                <menuItem title="Allow Display To Sleep" state="on" id="pFx-q3-0Qh">
+                <menuItem title="Prevent Display Sleep" state="on" id="pFx-q3-0Qh">
                     <modifierMask key="keyEquivalentModifierMask"/>
                     <connections>
                         <action selector="toggleSleepOption:" target="lVf-z2-2S9" id="NHc-LJ-hGX"/>
-                    </connections>
-                </menuItem>
-                <menuItem title="Allow System To Sleep" state="on" id="KqC-rJ-r1W">
-                    <modifierMask key="keyEquivalentModifierMask"/>
-                    <connections>
-                        <action selector="toggleSleepOption:" target="lVf-z2-2S9" id="VTr-LX-B8Y"/>
                     </connections>
                 </menuItem>
                 <menuItem isSeparatorItem="YES" id="aOi-yt-xjg"/>

--- a/VirtualKVM/Base.lproj/MainMenu.xib
+++ b/VirtualKVM/Base.lproj/MainMenu.xib
@@ -18,7 +18,7 @@
                 <outlet property="menu" destination="ZQU-Qi-o3m" id="mfM-jk-6Qf"/>
                 <outlet property="toggleBluetoothMenuItem" destination="5RI-2K-t5L" id="q2q-LS-th5"/>
                 <outlet property="toggleDisplayMenuItem" destination="Beb-Ne-3cM" id="e2R-MG-QZB"/>
-                <outlet property="toggleIdleSleepMenuItem" destination="pFx-q3-0Qh" id="YFB-yG-DEw"/>
+                <outlet property="toggleSleepMenuItem" destination="pFx-q3-0Qh" id="58O-CE-q2a"/>
             </connections>
         </customObject>
         <customObject id="Voe-Tx-rLC" customClass="KVMAppDelegate"/>

--- a/VirtualKVM/Base.lproj/MainMenu.xib
+++ b/VirtualKVM/Base.lproj/MainMenu.xib
@@ -1,8 +1,8 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="10116" systemVersion="15E65" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="11542" systemVersion="16B2555" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="10116"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="11542"/>
     </dependencies>
     <objects>
         <customObject id="-2" userLabel="File's Owner" customClass="NSApplication">
@@ -16,10 +16,9 @@
             <connections>
                 <outlet property="connectionStatusMenuItem" destination="9wc-aF-0Uk" id="wCh-Cf-J3x"/>
                 <outlet property="menu" destination="ZQU-Qi-o3m" id="mfM-jk-6Qf"/>
-                <outlet property="toggleBluetoothMenuItem" destination="5RI-2K-t5L" id="ndn-UP-Y8j"/>
-                <outlet property="toggleDisplayMenuItem" destination="Beb-Ne-3cM" id="im0-2W-Fxf"/>
                 <outlet property="toggleBluetoothMenuItem" destination="5RI-2K-t5L" id="q2q-LS-th5"/>
                 <outlet property="toggleDisplayMenuItem" destination="Beb-Ne-3cM" id="e2R-MG-QZB"/>
+                <outlet property="toggleIdleSleepMenuItem" destination="pFx-q3-0Qh" id="YFB-yG-DEw"/>
                 <outlet property="toggleSleepMenuItem" destination="KqC-rJ-r1W" id="nqo-ba-9h6"/>
             </connections>
         </customObject>
@@ -43,7 +42,13 @@
                         <action selector="toggleTargetDisplayOption:" target="lVf-z2-2S9" id="b5O-ZI-yr6"/>
                     </connections>
                 </menuItem>
-                <menuItem title="Auto Disable Sleep" state="on" id="KqC-rJ-r1W">
+                <menuItem title="Auto Disable Idle Sleep" state="on" id="pFx-q3-0Qh">
+                    <modifierMask key="keyEquivalentModifierMask"/>
+                    <connections>
+                        <action selector="toggleSleepOption:" target="lVf-z2-2S9" id="NHc-LJ-hGX"/>
+                    </connections>
+                </menuItem>
+                <menuItem title="Auto Disable Display Sleep" state="on" id="KqC-rJ-r1W">
                     <modifierMask key="keyEquivalentModifierMask"/>
                     <connections>
                         <action selector="toggleSleepOption:" target="lVf-z2-2S9" id="VTr-LX-B8Y"/>

--- a/VirtualKVM/GVUserDefaults+KVMApp.h
+++ b/VirtualKVM/GVUserDefaults+KVMApp.h
@@ -5,7 +5,6 @@
 @property (nonatomic) BOOL toggleBluetooth;
 @property (nonatomic) BOOL toggleTargetDisplayMode;
 @property (nonatomic) BOOL toggleDisableSleep;
-@property (nonatomic) BOOL toggleDisableIdleSleep;
 
 
 - (NSDictionary *)setupDefaults;

--- a/VirtualKVM/GVUserDefaults+KVMApp.h
+++ b/VirtualKVM/GVUserDefaults+KVMApp.h
@@ -5,6 +5,8 @@
 @property (nonatomic) BOOL toggleBluetooth;
 @property (nonatomic) BOOL toggleTargetDisplayMode;
 @property (nonatomic) BOOL toggleDisableSleep;
+@property (nonatomic) BOOL toggleDisableIdleSleep;
+
 
 - (NSDictionary *)setupDefaults;
 

--- a/VirtualKVM/GVUserDefaults+KVMApp.m
+++ b/VirtualKVM/GVUserDefaults+KVMApp.m
@@ -5,14 +5,12 @@
 @dynamic toggleBluetooth;
 @dynamic toggleTargetDisplayMode;
 @dynamic toggleDisableSleep;
-@dynamic toggleDisableIdleSleep;
-    
+
 - (NSDictionary *)setupDefaults {
   return @{
     @"toggleBluetooth": @YES,
     @"toggleTargetDisplayMode": @YES,
     @"toggleDisableSleep": @YES,
-    @"toggleDisableIdleSleep":@NO,
   };
 }
 

--- a/VirtualKVM/GVUserDefaults+KVMApp.m
+++ b/VirtualKVM/GVUserDefaults+KVMApp.m
@@ -5,12 +5,14 @@
 @dynamic toggleBluetooth;
 @dynamic toggleTargetDisplayMode;
 @dynamic toggleDisableSleep;
-
+@dynamic toggleDisableIdleSleep;
+    
 - (NSDictionary *)setupDefaults {
   return @{
     @"toggleBluetooth": @YES,
     @"toggleTargetDisplayMode": @YES,
     @"toggleDisableSleep": @YES,
+    @"toggleDisableIdleSleep":@NO,
   };
 }
 

--- a/VirtualKVM/KVMController.m
+++ b/VirtualKVM/KVMController.m
@@ -18,7 +18,6 @@
 @property (weak) IBOutlet NSMenuItem *toggleDisplayMenuItem;
 @property (weak) IBOutlet NSMenuItem *toggleSleepMenuItem;
 @property (weak) IBOutlet NSMenuItem *connectionStatusMenuItem;
-@property (weak) IBOutlet NSMenuItem *toggleIdleSleepMenuItem;
 
 @end
 
@@ -62,7 +61,6 @@
   self.toggleBluetoothMenuItem.state = [GVUserDefaults standardUserDefaults].toggleBluetooth ? NSOnState : NSOffState;
   self.toggleDisplayMenuItem.state = [GVUserDefaults standardUserDefaults].toggleTargetDisplayMode ? NSOnState : NSOffState;
   self.toggleSleepMenuItem.state = [GVUserDefaults standardUserDefaults].toggleDisableSleep ? NSOnState : NSOffState;
- self.toggleIdleSleepMenuItem.state = [GVUserDefaults standardUserDefaults].toggleDisableIdleSleep ? NSOnState : NSOffState;
 
   self.connectionStatusMenuItem.title = [NSString stringWithFormat:@"%@: %@", [self modeString], NSLocalizedString(@"Initializing …", comment:"State when the application is initializing.")];
 
@@ -70,10 +68,8 @@
     self.toggleDisplayMenuItem.hidden = YES;
     NSLog(NSLocalizedString(@"Running in %@.", comment:@"Example: Running in Client Mode."), [self modeString]);
   } else {
-      self.toggleIdleSleepMenuItem.hidden = YES;
       self.toggleSleepMenuItem.hidden = YES;
       [GVUserDefaults standardUserDefaults].toggleDisableSleep = NO;
-      [GVUserDefaults standardUserDefaults].toggleDisableIdleSleep = NO;
   }
 
   self.statusItem = [KVMStatusItem statusItemWithMenu:self.menu];
@@ -108,36 +104,13 @@
 - (IBAction)toggleSleepOption:(id)sender {
   NSMenuItem *menuItem = (NSMenuItem *)sender;
 
-    if (menuItem == self.toggleIdleSleepMenuItem) {
-        
-        if (menuItem.state == NSOnState) {
-            menuItem.state = NSOffState;
-            self.toggleSleepMenuItem.enabled = YES;
-        } else {
-            self.toggleSleepMenuItem.enabled = NO;
-            menuItem.state = NSOnState;
-        }
-    }
-    
-    if (menuItem == self.toggleSleepMenuItem) {
-        
-        if (menuItem.state == NSOnState) {
-            menuItem.state = NSOffState;
-            self.toggleIdleSleepMenuItem.enabled = YES;
-        } else {
-            self.toggleIdleSleepMenuItem.enabled = NO;
-            menuItem.state = NSOnState;
-        }
-    }
+  if (menuItem.state == NSOnState) {
+    menuItem.state = NSOffState;
+  } else {
+    menuItem.state = NSOnState;
+  }
 
-    if (menuItem == self.toggleIdleSleepMenuItem) {
-        
-        [GVUserDefaults standardUserDefaults].toggleDisableIdleSleep = menuItem.state == NSOnState;
-
-    } else if (menuItem == self.toggleSleepMenuItem) {
-        
-        [GVUserDefaults standardUserDefaults].toggleDisableSleep = menuItem.state == NSOnState;
-    }
+  [GVUserDefaults standardUserDefaults].toggleDisableSleep = menuItem.state == NSOnState;
 }
 
 - (IBAction)quit:(id)sender {

--- a/VirtualKVM/KVMController.m
+++ b/VirtualKVM/KVMController.m
@@ -71,6 +71,8 @@
   } else {
       self.toggleIdleSleepMenuItem.hidden = YES;
       self.toggleSleepMenuItem.hidden = YES;
+      [GVUserDefaults standardUserDefaults].toggleDisableSleep = NO;
+      [GVUserDefaults standardUserDefaults].toggleDisableIdleSleep = NO;
   }
 
   self.statusItem = [KVMStatusItem statusItemWithMenu:self.menu];

--- a/VirtualKVM/KVMController.m
+++ b/VirtualKVM/KVMController.m
@@ -168,12 +168,35 @@
 }
 
 #pragma mark - Helpers
-
+- (void)pressBrightnessKeys {
+    
+    CGEventSourceRef src = CGEventSourceCreate(kCGEventSourceStateHIDSystemState);
+    CGEventRef turnBrightnessUpKeyUp = CGEventCreateKeyboardEvent(src, 0x90, true);
+    CGEventRef turnBrightnessUpKeyDown = CGEventCreateKeyboardEvent(src, 0x90, false);
+    
+    CGEventRef turnBrightnessDownKeyUp = CGEventCreateKeyboardEvent(src, 0x91, true);
+    CGEventRef turnBrightnessDownKeyDown = CGEventCreateKeyboardEvent(src, 0x91, false);
+    
+    CGEventTapLocation loc = kCGHIDEventTap;
+    CGEventPost(loc, turnBrightnessUpKeyUp);
+    CGEventPost(loc, turnBrightnessUpKeyDown);
+    
+    CGEventPost(loc, turnBrightnessDownKeyUp);
+    CGEventPost(loc, turnBrightnessDownKeyDown);
+    
+    CFRelease(turnBrightnessUpKeyUp);
+    CFRelease(turnBrightnessUpKeyDown);
+    CFRelease(turnBrightnessDownKeyUp);
+    CFRelease(turnBrightnessDownKeyDown);
+    CFRelease(src);
+}
 - (void)enableTargetDisplayMode {
   if ([self.thunderboltObserver isInTargetDisplayMode]) {
     return;
   }
 
+  [self pressBrightnessKeys];
+    
   CGEventSourceRef src = CGEventSourceCreate(kCGEventSourceStateHIDSystemState);
 
   CGEventRef f2d = CGEventCreateKeyboardEvent(src, 0x90, true);

--- a/VirtualKVM/KVMController.m
+++ b/VirtualKVM/KVMController.m
@@ -102,11 +102,27 @@
 - (IBAction)toggleSleepOption:(id)sender {
   NSMenuItem *menuItem = (NSMenuItem *)sender;
 
-  if (menuItem.state == NSOnState) {
-    menuItem.state = NSOffState;
-  } else {
-    menuItem.state = NSOnState;
-  }
+    if (menuItem == self.toggleIdleSleepMenuItem) {
+        
+        if (menuItem.state == NSOnState) {
+            menuItem.state = NSOffState;
+            self.toggleSleepMenuItem.enabled = YES;
+        } else {
+            self.toggleSleepMenuItem.enabled = NO;
+            menuItem.state = NSOnState;
+        }
+    }
+    
+    if (menuItem == self.toggleSleepMenuItem) {
+        
+        if (menuItem.state == NSOnState) {
+            menuItem.state = NSOffState;
+            self.toggleIdleSleepMenuItem.enabled = YES;
+        } else {
+            self.toggleIdleSleepMenuItem.enabled = NO;
+            menuItem.state = NSOnState;
+        }
+    }
 
     if (menuItem == self.toggleIdleSleepMenuItem) {
         

--- a/VirtualKVM/KVMController.m
+++ b/VirtualKVM/KVMController.m
@@ -207,9 +207,9 @@
     IOReturn success = IOPMAssertionCreateWithName(assertionType, kIOPMAssertionLevelOn, reasonForActivity, &_sleepAssertion);
 
     if (success == kIOReturnSuccess) {
-      NSLog(NSLocalizedString(@"Sleep disabled.", comment:nil));
+      NSLog(NSLocalizedString(@"Created power assertion. Assertion type: %@", nil),assertionType);
     } else {
-      NSLog(NSLocalizedString(@"Error disabling sleep.", comment:nil));
+      NSLog(NSLocalizedString(@"Unable to create power assertion.", comment:nil));
     }
   
 }
@@ -219,9 +219,9 @@
     IOReturn success = IOPMAssertionRelease(self.sleepAssertion);
 
     if (success == kIOReturnSuccess) {
-      NSLog(NSLocalizedString(@"Sleep enabled.", comment:nil));
+      NSLog(NSLocalizedString(@"Release power assertion.", comment:nil));
     } else {
-      NSLog(NSLocalizedString(@"Error enabling sleep.", comment:nil));
+      NSLog(NSLocalizedString(@"Unable to release power assertion.", comment:nil));
     }
   }
 }

--- a/VirtualKVM/KVMController.m
+++ b/VirtualKVM/KVMController.m
@@ -216,7 +216,10 @@
   CFRelease(f2d);
   CFRelease(f2u);
   CFRelease(src);
-
+    
+    if (!self.isClient) {
+        return;
+    }
     if (_sleepAssertion) {//If we already have an `_sleepAssertion` then we are already holding a power assertion.
         return;
     }

--- a/VirtualKVM/KVMController.m
+++ b/VirtualKVM/KVMController.m
@@ -168,35 +168,12 @@
 }
 
 #pragma mark - Helpers
-- (void)pressBrightnessKeys {
-    
-    CGEventSourceRef src = CGEventSourceCreate(kCGEventSourceStateHIDSystemState);
-    CGEventRef turnBrightnessUpKeyUp = CGEventCreateKeyboardEvent(src, 0x90, true);
-    CGEventRef turnBrightnessUpKeyDown = CGEventCreateKeyboardEvent(src, 0x90, false);
-    
-    CGEventRef turnBrightnessDownKeyUp = CGEventCreateKeyboardEvent(src, 0x91, true);
-    CGEventRef turnBrightnessDownKeyDown = CGEventCreateKeyboardEvent(src, 0x91, false);
-    
-    CGEventTapLocation loc = kCGHIDEventTap;
-    CGEventPost(loc, turnBrightnessUpKeyUp);
-    CGEventPost(loc, turnBrightnessUpKeyDown);
-    
-    CGEventPost(loc, turnBrightnessDownKeyUp);
-    CGEventPost(loc, turnBrightnessDownKeyDown);
-    
-    CFRelease(turnBrightnessUpKeyUp);
-    CFRelease(turnBrightnessUpKeyDown);
-    CFRelease(turnBrightnessDownKeyUp);
-    CFRelease(turnBrightnessDownKeyDown);
-    CFRelease(src);
-}
+
 - (void)enableTargetDisplayMode {
   if ([self.thunderboltObserver isInTargetDisplayMode]) {
     return;
   }
 
-  [self pressBrightnessKeys];
-    
   CGEventSourceRef src = CGEventSourceCreate(kCGEventSourceStateHIDSystemState);
 
   CGEventRef f2d = CGEventCreateKeyboardEvent(src, 0x90, true);

--- a/VirtualKVM/KVMController.m
+++ b/VirtualKVM/KVMController.m
@@ -68,6 +68,9 @@
   if (self.isClient) {
     self.toggleDisplayMenuItem.hidden = YES;
     NSLog(NSLocalizedString(@"Running in %@.", comment:@"Example: Running in Client Mode."), [self modeString]);
+  } else {
+      self.toggleIdleSleepMenuItem.hidden = YES;
+      self.toggleSleepMenuItem.hidden = YES;
   }
 
   self.statusItem = [KVMStatusItem statusItemWithMenu:self.menu];

--- a/VirtualKVM/KVMController.m
+++ b/VirtualKVM/KVMController.m
@@ -217,6 +217,9 @@
   CFRelease(f2u);
   CFRelease(src);
 
+    if (_sleepAssertion) {//If we already have an `_sleepAssertion` then we are already holding a power assertion.
+        return;
+    }
     CFStringRef assertionType = nil;
     
     if ([GVUserDefaults standardUserDefaults].toggleDisableSleep) {

--- a/VirtualKVM/KVMController.m
+++ b/VirtualKVM/KVMController.m
@@ -18,6 +18,7 @@
 @property (weak) IBOutlet NSMenuItem *toggleDisplayMenuItem;
 @property (weak) IBOutlet NSMenuItem *toggleSleepMenuItem;
 @property (weak) IBOutlet NSMenuItem *connectionStatusMenuItem;
+@property (nonatomic, assign) CFStringRef assertionType;
 
 @end
 
@@ -196,18 +197,18 @@
     if (_sleepAssertion) {//If we already have an `_sleepAssertion` then we are already holding a power assertion.
         return;
     }
-    CFStringRef assertionType = nil;
+    self.assertionType = nil;
     
     if ([GVUserDefaults standardUserDefaults].toggleDisableSleep) {
-        assertionType = kIOPMAssertPreventUserIdleDisplaySleep;
+        self.assertionType = kIOPMAssertPreventUserIdleDisplaySleep;
     } else {
-        assertionType = kIOPMAssertPreventUserIdleSystemSleep;
+        self.assertionType = kIOPMAssertPreventUserIdleSystemSleep;
     }
     CFStringRef reasonForActivity = (__bridge CFStringRef)@"In Target Display Mode";
-    IOReturn success = IOPMAssertionCreateWithName(assertionType, kIOPMAssertionLevelOn, reasonForActivity, &_sleepAssertion);
+    IOReturn success = IOPMAssertionCreateWithName(self.assertionType, kIOPMAssertionLevelOn, reasonForActivity, &_sleepAssertion);
 
     if (success == kIOReturnSuccess) {
-      NSLog(NSLocalizedString(@"Created power assertion. Assertion type: %@", nil),assertionType);
+      NSLog(NSLocalizedString(@"Created power assertion. Assertion type: %@", comment:nil),self.assertionType);
     } else {
       NSLog(NSLocalizedString(@"Unable to create power assertion.", comment:nil));
     }
@@ -219,9 +220,9 @@
     IOReturn success = IOPMAssertionRelease(self.sleepAssertion);
 
     if (success == kIOReturnSuccess) {
-      NSLog(NSLocalizedString(@"Release power assertion.", comment:nil));
+      NSLog(NSLocalizedString(@"Released power assertion. Assertion type: %@", comment:nil),self.assertionType);
     } else {
-      NSLog(NSLocalizedString(@"Unable to release power assertion.", comment:nil));
+      NSLog(NSLocalizedString(@"Unable to release power assertion. Assertion type: %@", comment:nil),self.assertionType);
     }
   }
 }

--- a/VirtualKVM/KVMController.m
+++ b/VirtualKVM/KVMController.m
@@ -219,7 +219,7 @@
 
     CFStringRef assertionType = nil;
     
-    if ([GVUserDefaults standardUserDefaults].toggleTargetDisplayMode) {
+    if ([GVUserDefaults standardUserDefaults].toggleDisableSleep) {
         assertionType = kIOPMAssertPreventUserIdleDisplaySleep;
     } else {
         assertionType = kIOPMAssertPreventUserIdleSystemSleep;

--- a/VirtualKVM/KVMController.m
+++ b/VirtualKVM/KVMController.m
@@ -188,7 +188,7 @@
 
   if ([GVUserDefaults standardUserDefaults].toggleDisableSleep) {
     CFStringRef reasonForActivity = (__bridge CFStringRef)@"In Target Display Mode";
-    IOReturn success = IOPMAssertionCreateWithName(kIOPMAssertionTypeNoDisplaySleep, kIOPMAssertionLevelOn, reasonForActivity, &_sleepAssertion);
+    IOReturn success = IOPMAssertionCreateWithName(kIOPMAssertPreventUserIdleSystemSleep, kIOPMAssertionLevelOn, reasonForActivity, &_sleepAssertion);
 
     if (success == kIOReturnSuccess) {
       NSLog(NSLocalizedString(@"Sleep disabled.", comment:nil));

--- a/VirtualKVM/KVMController.m
+++ b/VirtualKVM/KVMController.m
@@ -58,6 +58,7 @@
 }
 
 - (void)awakeFromNib {
+  self.menu.autoenablesItems = NO;
   self.toggleBluetoothMenuItem.state = [GVUserDefaults standardUserDefaults].toggleBluetooth ? NSOnState : NSOffState;
   self.toggleDisplayMenuItem.state = [GVUserDefaults standardUserDefaults].toggleTargetDisplayMode ? NSOnState : NSOffState;
   self.toggleSleepMenuItem.state = [GVUserDefaults standardUserDefaults].toggleDisableSleep ? NSOnState : NSOffState;

--- a/VirtualKVM/KVMController.m
+++ b/VirtualKVM/KVMController.m
@@ -66,7 +66,7 @@
   self.connectionStatusMenuItem.title = [NSString stringWithFormat:@"%@: %@", [self modeString], NSLocalizedString(@"Initializing …", comment:"State when the application is initializing.")];
 
   if (self.isClient) {
-    self.toggleDisplayMenuItem.enabled = NO;
+    self.toggleDisplayMenuItem.hidden = YES;
     NSLog(NSLocalizedString(@"Running in %@.", comment:@"Example: Running in Client Mode."), [self modeString]);
   }
 


### PR DESCRIPTION
**Fix:**
* 	Fix issue that caused assertion to be created multiple times
![screen shot 2016-11-16 at 8 48 59 pm](https://cloud.githubusercontent.com/assets/4827301/20372360/004e48a2-ac41-11e6-9070-b04205ce3c04.png)

**Notable Changes:**
* Will only show sleep menu items on client. The iMac will not show these options. "While in Target Display Mode, the host iMac automatically ignores any scheduled sleep commands and keeps the system running as long as the source’s video signal is flowing. If your source device sleeps, however, it will break the connection and the host iMac will revert to the internal display." - https://www.tekrevue.com/tip/ins-outs-imacs-target-display-mode/

* `Allow Display To Sleep` will prevent the client from going into idle sleep.
* `Allow System To Sleep` will prevent the client's display from going to sleep.
*  `Auto Toggle Display` will not hidden on the client side.


Client View:
<img width="258" alt="screen shot 2016-11-16 at 9 17 13 pm" src="https://cloud.githubusercontent.com/assets/4827301/20372509/18bae71e-ac42-11e6-9bfe-9bdadd8401f4.png">

Host View:
![screen shot 2016-11-16 at 9 16 17 pm](https://cloud.githubusercontent.com/assets/4827301/20372512/1e02cc0a-ac42-11e6-8b48-1ac5f037d42b.png)

I'm still testing this particularly in regards to having `Allow Display To Sleep` on. I want to test if I can have the iMac's display *off* while still being connected to my rMBP. If I wake my rMBP I want to see if the iMac's display will *turn* back on. Note that the machine will be clamshell mode.

**Update**: Just tested it and it works. On the client side, having none of the sleep options check, when the MacBook when display turned off the iMac would exit TDM. However, when I checked `Allow Display To Sleep` and the Macbook's display turned off TDM, was still active but the iMac's display was *off*. Once, I woke my computer (via the keyboard) the iMac's display lit up and the MacBook's display showed instead of the iMac's display.

**Update 2:** I think I might want to change the sleep menu items to just one: `Allow Display To Sleep`. If `Allow Display To Sleep` is not checked then the app will hold `kIOPMAssertPreventUserIdleDisplaySleep`.