### PR TITLE
fix crash in OSX Sierra 10.12.6

### DIFF
--- a/VirtualKVM.xcodeproj/project.pbxproj
+++ b/VirtualKVM.xcodeproj/project.pbxproj
@@ -342,7 +342,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n";
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n";
 			showEnvVarsInLog = 0;
 		};
 		499F7C25E03D884A58C90A9C /* [CP] Check Pods Manifest.lock */ = {
@@ -357,7 +357,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n";
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n";
 			showEnvVarsInLog = 0;
 		};
 		58C91F90D2DB4CDD08B23BE9 /* [CP] Embed Pods Frameworks */ = {

--- a/VirtualKVM/KVMThunderboltObserver.m
+++ b/VirtualKVM/KVMThunderboltObserver.m
@@ -38,17 +38,12 @@ typedef void (^DispatchRepeatBlock)(DispatchRepeatCompletionHandler completionHa
 // Determines if the host has thunderbolt ports
 - (BOOL)isThunderboltEnabled {
     
-    NSArray *profilerResponse = [self systemProfilerThunderboltInfo];
+    NSDictionary *profilerResponse = [self systemProfilerThunderboltInfo];
     
     if (profilerResponse.count >= 1) {
+        NSArray *items = profilerResponse[@"_items"];
         
-        NSDictionary *info = profilerResponse[0];
-        if (info.count == 0) {
-            return NO;
-        }
-        NSArray *items = info[@"_items"];
-        
-        if (items.count == 0) {
+        if (!items || items.count == 0) {
             return NO;
         }
         NSString *busName = items[0][@"_name"];
@@ -61,6 +56,7 @@ typedef void (^DispatchRepeatBlock)(DispatchRepeatCompletionHandler completionHa
     
     return NO;
 }
+
 
 - (void)registerRepeatBlock {
     


### PR DESCRIPTION
It seems that perhaps the Objective-C API changed in OSX Sierra because the app crashes in KVMThunderboltObserver.m.  In the method isThunderboltEnabled() the call to systemProfilerThunderboltInfo() returns an NSDictionary, not an NSArray.  The following code corrects the problem...

```objc
- (BOOL)isThunderboltEnabled {
    
    NSDictionary *profilerResponse = [self systemProfilerThunderboltInfo];
    
    if (profilerResponse.count >= 1) {
        NSArray *items = profilerResponse[@"_items"];
        
        if (!items || items.count == 0) {
            return NO;
        }
        NSString *busName = items[0][@"_name"];
        
        if ([busName isEqualToString:@"thunderbolt_bus"]) {
            return YES;
        }
        return NO;
    }
    
    return NO;
}
```